### PR TITLE
remove handler key from settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+## [1.1.0] - 2017-07
+### Fixed
+- metrics-statuspageio.rb: remove 'handlers' key from settings variable(@chrissav)
+
 ## [1.1.0] - 2017-06
 ### Added
 - handler-statuspage.rb: add ability to send requests through an unauthenticated proxy (@drhey)

--- a/bin/metrics-statuspageio.rb
+++ b/bin/metrics-statuspageio.rb
@@ -43,13 +43,13 @@ class StatusPageIOMetrics < Sensu::Handler
 
   def handle
     # Grab page_id and api_key from dashboard
-    @api_key = settings['handlers']['statuspageio_metrics']['api_key']
-    @page_id = settings['handlers']['statuspageio_metrics']['page_id']
+    @api_key = settings['statuspageio_metrics']['api_key']
+    @page_id = settings['statuspageio_metrics']['page_id']
 
     # Get a dict of metric_from_output => metric_ids
     # This allows the re-use of standard metrics plugins that can be mapped to
     # statuspage io metrics
-    @metrics = settings['handlers']['statuspageio_metrics']['metrics'] || {}
+    @metrics = settings['statuspageio_metrics']['metrics'] || {}
 
     # Split graphite-style metrics
     @event['check']['output'].split(/\n/).each do |m|


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
No

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
Receiving the following error when running this plugin:
```
["/etc/sensu/plugins/metrics-statuspageio.rb:46:in `handle': undefined method `[]' for nil:NilClass (NoMethodError)\n\tfrom /opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-plugin-1.4.2/lib/sensu-handler.rb:81:in `block in <class:Handler>'\n"]
```
This change started sending metrics to statuspage.  [handler-statuspage.rb L89](https://github.com/sensu-plugins/sensu-plugins-statuspage/blob/master/bin/handler-statuspage.rb#L89) retrieves the api_key and page_id from `settings` in the same way.

#### Known Compatibility Issues
No
